### PR TITLE
Replace CoHTTP by a abstract interface

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,6 +1,6 @@
 (executable
   (name oacmel)
   (public_name oacmel)
-  (package letsencrypt)
+  (package letsencrypt-app)
   (modules oacmel)
-  (libraries letsencrypt ptime.clock.os ipaddr.unix cohttp-lwt-unix fpath bos randomconv cmdliner mirage-crypto-rng.unix fmt.cli fmt.tty logs.fmt logs.cli))
+  (libraries letsencrypt letsencrypt-dns ptime.clock.os ipaddr.unix cohttp-lwt-unix fpath bos randomconv cmdliner mirage-crypto-rng.unix fmt.cli fmt.tty logs.fmt logs.cli))

--- a/bin/oacmel.ml
+++ b/bin/oacmel.ml
@@ -61,10 +61,10 @@ let main _ rsa_pem csr_pem email solver acme_dir ip key endpoint cert zone =
               | Some x -> Domain_name.(host_exn (of_string_exn x))
             in
             let random_id = Randomconv.int16 Mirage_crypto_rng.generate in
-            Letsencrypt.Client.nsupdate random_id Ptime_clock.now (dns_out ip') ~keyname key ~zone
+            Letsencrypt_dns.nsupdate random_id Ptime_clock.now (dns_out ip') ~keyname key ~zone
           | Some `Dns, None, None, None ->
             Logs.app (fun m -> m "using dns solver");
-            Letsencrypt.Client.print_dns
+            Letsencrypt_dns.print_dns
           | Some `Http, None, None, None ->
             Logs.app (fun m -> m "using http solver");
             Letsencrypt.Client.print_http

--- a/bin/oacmel.ml
+++ b/bin/oacmel.ml
@@ -1,6 +1,18 @@
 open Lwt.Infix
 
-module Acme_cli = Letsencrypt.Client.Make(Cohttp_lwt_unix.Client)
+module HTTP_client = struct
+  module Headers = Cohttp.Header
+  module Body = Cohttp_lwt.Body
+
+  module Response = struct
+    include Cohttp.Response
+    let status resp = Cohttp.Code.code_of_status (Cohttp.Response.status resp)
+  end
+
+  include Cohttp_lwt_unix.Client
+end
+
+module Acme_cli = Letsencrypt.Client.Make(HTTP_client)
 
 let dns_out ip cs =
   let out = Lwt_unix.(socket PF_INET SOCK_DGRAM 0) in

--- a/dns/dune
+++ b/dns/dune
@@ -1,0 +1,4 @@
+(library
+ (name letsencrypt_dns)
+ (public_name letsencrypt-dns)
+ (libraries letsencrypt logs lwt dns dns-tsig))

--- a/dns/letsencrypt_dns.ml
+++ b/dns/letsencrypt_dns.ml
@@ -1,0 +1,62 @@
+let src = Logs.Src.create "letsencrypt.dns" ~doc:"let's encrypt library"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+open Lwt.Infix
+
+let dns_solver writef =
+  let solve_challenge ~token:_ ~key_authorization domain =
+    let solution = Letsencrypt.sha256_and_base64 key_authorization in
+    let domain_name = Domain_name.prepend_label_exn domain "_acme-challenge" in
+    writef domain_name solution
+  in
+  { Letsencrypt.Client.typ = `Dns ; solve_challenge }
+
+let print_dns =
+  let solve domain solution =
+    Log.warn (fun f -> f "Setup a TXT record for %a to return %s and press enter to continue"
+                 Domain_name.pp domain solution);
+    ignore (read_line ());
+    Lwt.return_ok ()
+  in
+  dns_solver solve
+
+let nsupdate ?proto id now out ?recv ~zone ~keyname key =
+  let open Dns in
+  let nsupdate name record =
+    Log.info (fun m -> m "solving dns by update to! %a (name %a)"
+                 Domain_name.pp zone Domain_name.pp name);
+    let zone = Packet.Question.create zone Rr_map.Soa
+    and update =
+      let up =
+        Domain_name.Map.singleton name
+          [
+            Packet.Update.Remove (Rr_map.K Txt) ;
+            Packet.Update.Add Rr_map.(B (Txt, (3600l, Txt_set.singleton record)))
+      ]
+      in
+      (Domain_name.Map.empty, up)
+    and header = (id, Packet.Flags.empty)
+    in
+    let packet = Packet.create header zone (`Update update) in
+    match Dns_tsig.encode_and_sign ?proto packet (now ()) key keyname with
+    | Error s -> Lwt.return_error (`Msg (Fmt.to_to_string Dns_tsig.pp_s s))
+    | Ok (data, mac) ->
+      out data >>= function
+      | Error err -> Lwt.return_error err
+      | Ok () ->
+        match recv with
+        | None -> Lwt.return_ok ()
+        | Some recv -> recv () >|= function
+          | Error e -> Error e
+          | Ok data ->
+            match Dns_tsig.decode_and_verify (now ()) key keyname ~mac data with
+            | Error e -> Error (`Msg (Fmt.strf "decode and verify error %a" Dns_tsig.pp_e e))
+            | Ok (res, _, _) ->
+              match Packet.reply_matches_request ~request:packet res with
+              | Ok _ -> Ok ()
+              | Error mismatch ->
+                Error (`Msg (Fmt.strf "error %a expected reply to %a, got %a"
+                               Packet.pp_mismatch mismatch
+                               Packet.pp packet Packet.pp res))
+  in
+  dns_solver nsupdate

--- a/dns/letsencrypt_dns.mli
+++ b/dns/letsencrypt_dns.mli
@@ -1,0 +1,25 @@
+(** [dns_solver (fun domain content)] is a solver for dns-01 challenges.
+    The provided function should return [Ok ()] once the authoritative
+    name servers serve a TXT record at [domain] with the content. The
+    [domain] already has the [_acme-challenge.] prepended. *)
+val dns_solver :
+  ([`raw] Domain_name.t -> string ->
+   (unit, [ `Msg of string ]) result Lwt.t) -> Letsencrypt.Client.solver
+
+(** [print_dns] outputs the DNS challenge solution, and waits for user input
+    before continuing with ACME. *)
+val print_dns : Letsencrypt.Client.solver
+
+(** [nsupdate ~proto id now send ~recv ~keyname key ~zone]
+    constructs a dns solver that sends a DNS update packet (using [send])
+    and optionally waits for a signed reply (using [recv] if present) to solve
+    challenges. The update is signed with a hmac transaction signature
+    (DNS TSIG) using [now ()] as timestamp, and the [keyname] and [key] for
+    the cryptographic material. The [zone] is the one to be used in the
+    query section of the update packet. If signing, sending, or receiving
+    fails, the error is reported. *)
+val nsupdate : ?proto:Dns.proto -> int -> (unit -> Ptime.t) ->
+  (Cstruct.t -> (unit, [ `Msg of string ]) result Lwt.t) ->
+  ?recv:(unit -> (Cstruct.t, [ `Msg of string ]) result Lwt.t) ->
+  zone:[ `host ] Domain_name.t ->
+  keyname:'a Domain_name.t -> Dns.Dnskey.t -> Letsencrypt.Client.solver

--- a/letsencrypt-app.opam
+++ b/letsencrypt-app.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "ACME implementation in OCaml"
-description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
 maintainer: "Michele Mu <maker@tumbolandia.net>"
 authors:
   "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
@@ -11,20 +11,18 @@ doc: "https://mmaker.github.io/ocaml-letsencrypt"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2.0"}
-  "astring"
-  "rresult"
-  "base64" {>= "3.1.0"}
+  "letsencrypt" #{= version}
+  "letsencrypt-dns" #{= version}
+  "cmdliner"
+  "cohttp-lwt-unix" {>= "1.0.0"}
   "logs"
   "fmt"
   "lwt" {>= "2.6.0"}
-  "mirage-crypto"
-  "mirage-crypto-pk"
-  "mirage-crypto-pk" {with-test & >= "0.8.9"}
-  "x509" {>= "0.13.0"}
-  "yojson" {>= "1.6.0"}
-  "ounit" {with-test}
+  "mirage-crypto-rng"
   "ptime"
-  "domain-name" {>= "0.2.0"}
+  "bos"
+  "fpath"
+  "randomconv"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/letsencrypt-dns.opam
+++ b/letsencrypt-dns.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "ACME implementation in OCaml"
-description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
 maintainer: "Michele Mu <maker@tumbolandia.net>"
 authors:
   "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
@@ -11,19 +11,13 @@ doc: "https://mmaker.github.io/ocaml-letsencrypt"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2.0"}
-  "astring"
-  "rresult"
-  "base64" {>= "3.1.0"}
+  "letsencrypt" #{= version}
+  "mirage-crypto"
   "logs"
   "fmt"
   "lwt" {>= "2.6.0"}
-  "mirage-crypto"
-  "mirage-crypto-pk"
-  "mirage-crypto-pk" {with-test & >= "0.8.9"}
-  "x509" {>= "0.13.0"}
-  "yojson" {>= "1.6.0"}
-  "ounit" {with-test}
-  "ptime"
+  "dns"
+  "dns-tsig"
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/letsencrypt.opam
+++ b/letsencrypt.opam
@@ -16,7 +16,6 @@ depends: [
   "base64" {>= "3.1.0"}
   "cmdliner"
   "cohttp"
-  "cohttp-lwt" {>= "2.5.1"}
   "cohttp-lwt-unix" {>= "1.0.0"}
   "zarith"
   "logs"

--- a/src/acme_client.ml
+++ b/src/acme_client.ml
@@ -46,64 +46,6 @@ let print_http =
   in
   http_solver solve
 
-let dns_solver writef =
-  let solve_challenge ~token:_ ~key_authorization domain =
-    let solution = Primitives.sha256 key_authorization |> B64u.urlencode in
-    let domain_name = Domain_name.prepend_label_exn domain "_acme-challenge" in
-    writef domain_name solution
-  in
-  { typ = `Dns ; solve_challenge }
-
-let print_dns =
-  let solve domain solution =
-    Log.warn (fun f -> f "Setup a TXT record for %a to return %s and press enter to continue"
-                 Domain_name.pp domain solution);
-    ignore (read_line ());
-    Lwt.return_ok ()
-  in
-  dns_solver solve
-
-let nsupdate ?proto id now out ?recv ~zone ~keyname key =
-  let open Dns in
-  let nsupdate name record =
-    Log.info (fun m -> m "solving dns by update to! %a (name %a)"
-                 Domain_name.pp zone Domain_name.pp name);
-    let zone = Packet.Question.create zone Rr_map.Soa
-    and update =
-      let up =
-        Domain_name.Map.singleton name
-          [
-            Packet.Update.Remove (Rr_map.K Txt) ;
-            Packet.Update.Add Rr_map.(B (Txt, (3600l, Txt_set.singleton record)))
-      ]
-      in
-      (Domain_name.Map.empty, up)
-    and header = (id, Packet.Flags.empty)
-    in
-    let packet = Packet.create header zone (`Update update) in
-    match Dns_tsig.encode_and_sign ?proto packet (now ()) key keyname with
-    | Error s -> Lwt.return_error (`Msg (Fmt.to_to_string Dns_tsig.pp_s s))
-    | Ok (data, mac) ->
-      out data >>= function
-      | Error err -> Lwt.return_error err
-      | Ok () ->
-        match recv with
-        | None -> Lwt.return_ok ()
-        | Some recv -> recv () >|= function
-          | Error e -> Error e
-          | Ok data ->
-            match Dns_tsig.decode_and_verify (now ()) key keyname ~mac data with
-            | Error e -> Error (`Msg (Fmt.strf "decode and verify error %a" Dns_tsig.pp_e e))
-            | Ok (res, _, _) ->
-              match Packet.reply_matches_request ~request:packet res with
-              | Ok _ -> Ok ()
-              | Error mismatch ->
-                Error (`Msg (Fmt.strf "error %a expected reply to %a, got %a"
-                               Packet.pp_mismatch mismatch
-                               Packet.pp packet Packet.pp res))
-  in
-  dns_solver nsupdate
-
 let alpn_solver writef =
   (* on the ID-PE arc (from RFC 5280), 31 *)
   let id_pe_acme = Asn.OID.(base 1 3 <| 6 <| 1 <| 5 <| 5 <| 7 <| 1 <| 31)

--- a/src/acme_common.ml
+++ b/src/acme_common.ml
@@ -7,6 +7,9 @@ let letsencrypt_production_url =
 let letsencrypt_staging_url =
   Uri.of_string "https://acme-staging-v02.api.letsencrypt.org/directory"
 
+let sha256_and_base64 a =
+  Primitives.sha256 a |> B64u.urlencode
+
 module J = Yojson.Basic
 
 type json = J.t

--- a/src/acme_common.mli
+++ b/src/acme_common.mli
@@ -2,6 +2,8 @@ val letsencrypt_production_url : Uri.t
 
 val letsencrypt_staging_url : Uri.t
 
+val sha256_and_base64 : string -> string
+
 type json = Yojson.Basic.t
 
 val json_to_string : ?comma:string -> ?colon:string -> json -> string

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
 (library
  (name letsencrypt)
  (public_name letsencrypt)
- (libraries logs yojson lwt base64 mirage-crypto mirage-crypto-pk asn1-combinators x509 uri dns dns-tsig rresult astring cohttp-lwt))
+ (libraries logs yojson lwt base64 mirage-crypto mirage-crypto-pk asn1-combinators x509 uri dns dns-tsig rresult astring))

--- a/src/hTTP_client.ml
+++ b/src/hTTP_client.ml
@@ -1,0 +1,99 @@
+module type S = sig
+  type ctx
+  (** Type of the user-defined {i context}.
+
+      The context is an user-defined value which can be passed to your HTTP
+      client implementation to be able to tweak some internal details about the
+      underlying request/connection used to get an HTTP response.
+
+      For instance, an HTTP implementation can optionally require some value
+      such as the internal buffer size or a time-out value, etc. The interface
+      wants to {b allow} the implementer to pass such information via the [ctx]
+      type.
+
+      In others words, anything optionnaly needed to initiate/do the HTTP
+      request and that is not described over this interface (by arguments,
+      types, etc.) can be passed via the user-defined [ctx] type.
+
+      For instance, MirageOS uses this [ctx] as a ressource allocator to
+      initiate a TCP/IP connection or a TLS connection - and, by this way,
+      it fully abstracts the HTTP client implementation over the TCP/IP and
+      the TLS stack (for more details, see [mimic]).
+
+      Of course, [ctx = unit] if you don't need to pass extra-information when
+      you want to do an HTTP request/connection. *)
+
+  module Headers : sig
+    type t
+    (** The type of HTTP headers. *)
+
+    val add : t -> string -> string -> t
+    (** [add hdrs key value] adds a [key] and a [value] to an existing
+        [hdrs] headers. *)
+
+    val get : t -> string -> string option
+    (** [get hdrs key] retrieves a [key] from the given [hdrs] headers. If the
+        header is one of the set of headers defined to have list values, then
+        all of the values are concatenated into a single string separated by
+        commas and returned. If it is a singleton header, then the first value
+        is returned and no concatenation is performed. *)
+
+    val get_location : t -> Uri.t option
+    (** [get_location hdrs] is [get hdrs "location"]. *)
+
+    val init_with : string -> string -> t
+    (** [init_with key value] constructs a fresh map of HTTP headers with a
+        single key and value entry. *)
+
+    (** / *)
+
+    val to_string : t -> string
+  end
+
+  module Body : sig
+    type t
+    (** The type of HTTP body. *)
+
+    val of_string : string -> t
+    (** [of_string str] makes a body from the given [string] [str]. *)
+
+    val to_string : t -> string Lwt.t
+    (** [to_string body] returns the full given [body] as a [string]. *)
+  end
+
+  module Response : sig
+    type t
+    (** The type of HTTP response. *)
+
+    val status : t -> int
+    (** [status resp] is the HTTP status code of the response [resp]. *)
+
+    val headers : t -> Headers.t
+    (** [headers resp] is headers of the response [resp]. *)
+  end
+
+  val head :
+    ?ctx:ctx -> ?headers:Headers.t -> Uri.t -> Response.t Lwt.t
+  (** [head ?ctx ?headers uri] sends an {i HEAD} HTTP request to the given
+      [uri] and returns its response. The returned response does not have
+      a {i body} according to the HTTP standard. *)
+
+  val get :
+    ?ctx:ctx ->
+    ?headers:Headers.t ->
+    Uri.t ->
+    (Response.t * Body.t) Lwt.t
+  (** [get ?ctx ?headers uri] sends an {i GET} HTTP request to the given
+      [uri] and returns its response with its body. *)
+
+  val post :
+    ?ctx:ctx ->
+    ?body:Body.t ->
+    ?chunked:bool ->
+    ?headers:Headers.t ->
+    Uri.t ->
+    (Response.t * Body.t) Lwt.t
+  (** [post ?ctx ?body ?chunked ?headers uri] sends an {i POST} HTTP request
+      with the optional given [body] using chunked encoding if [chunked] is
+      [true] (default to [false]). It returns a response and a body. *)
+end

--- a/src/letsencrypt.ml
+++ b/src/letsencrypt.ml
@@ -1,3 +1,4 @@
 include Acme_common
 
+module HTTP_client = HTTP_client
 module Client = Acme_client

--- a/src/letsencrypt.mli
+++ b/src/letsencrypt.mli
@@ -9,6 +9,8 @@
 val letsencrypt_production_url : Uri.t
 val letsencrypt_staging_url : Uri.t
 
+val sha256_and_base64 : string -> string
+
 (** ACME Client.
 
     This module provides client commands.
@@ -20,7 +22,11 @@ val letsencrypt_staging_url : Uri.t
 module Client: sig
   type t
 
-  type solver
+  type solver = {
+    typ : [ `Dns | `Http | `Alpn ];
+    solve_challenge : token:string -> key_authorization:string ->
+      [`host] Domain_name.t -> (unit, [ `Msg of string]) result Lwt.t;
+  }
 
   (** [http_solver (fun domain ~prefix ~token ~content)] is a solver for
       http-01 challenges. The provided function should return [Ok ()] once the
@@ -35,32 +41,6 @@ module Client: sig
   (** [print_http] outputs the HTTP challenge solution, and waits for user input
       before continuing with ACME. *)
   val print_http : solver
-
-  (** [dns_solver (fun domain content)] is a solver for dns-01 challenges.
-      The provided function should return [Ok ()] once the authoritative
-      name servers serve a TXT record at [domain] with the content. The
-      [domain] already has the [_acme-challenge.] prepended. *)
-  val dns_solver :
-    ([`raw] Domain_name.t -> string ->
-     (unit, [ `Msg of string ]) result Lwt.t) -> solver
-
-  (** [print_dns] outputs the DNS challenge solution, and waits for user input
-      before continuing with ACME. *)
-  val print_dns : solver
-
-  (** [nsupdate ~proto id now send ~recv ~keyname key ~zone]
-      constructs a dns solver that sends a DNS update packet (using [send])
-      and optionally waits for a signed reply (using [recv] if present) to solve
-      challenges. The update is signed with a hmac transaction signature
-      (DNS TSIG) using [now ()] as timestamp, and the [keyname] and [key] for
-      the cryptographic material. The [zone] is the one to be used in the
-      query section of the update packet. If signing, sending, or receiving
-      fails, the error is reported. *)
-  val nsupdate : ?proto:Dns.proto -> int -> (unit -> Ptime.t) ->
-    (Cstruct.t -> (unit, [ `Msg of string ]) result Lwt.t) ->
-    ?recv:(unit -> (Cstruct.t, [ `Msg of string ]) result Lwt.t) ->
-    zone:[ `host ] Domain_name.t ->
-    keyname:'a Domain_name.t -> Dns.Dnskey.t -> solver
 
   (** [alpn_solver (fun domain ~alpn private_key certificate)] is a solver for
       tls-alpn-01 challenes. The provided function should return [Ok ()] once

--- a/src/letsencrypt.mli
+++ b/src/letsencrypt.mli
@@ -74,7 +74,7 @@ module Client: sig
       before continuing with ACME. *)
   val print_alpn : solver
 
-  module Make (Http : Cohttp_lwt.S.Client) : sig
+  module Make (Http : HTTP_client.S) : sig
 
     (** [initialise ~ctx ~endpoint ~email priv] constructs a [t] by
         looking up the directory and account of [priv] at [endpoint]. If no


### PR DESCRIPTION
This is a possible solution to delete CoHTTP from the core of `letsencrypt`. (/cc @hannesm)