### PR TITLE
Be able to specify protocols available for the ALPN server

### DIFF
--- a/mirage/lE_http_server.ml
+++ b/mirage/lE_http_server.ml
@@ -73,7 +73,7 @@ struct
       Alpn.injection;
     }
 
-  let with_lets_encrypt_certificates ?(port = 443) stackv4v6 ~production config
+  let with_lets_encrypt_certificates ?(port = 443) ?(alpn_protocols= [ "http/1.1"; "h2" ]) stackv4v6 ~production config
       client handler =
     let certificates = ref None in
     let stop_http_server = Lwt_switch.create () in
@@ -99,7 +99,7 @@ struct
       | None -> Lwt.return_error `No_certificates
       | Some certificates -> (
           let cfg =
-            Tls.Config.server ~alpn_protocols:[ "h2"; "http/1.1" ] ~certificates
+            Tls.Config.server ~alpn_protocols ~certificates
               () in
           Paf.TLS.server_of_flow cfg tcp >>= function
           | Ok flow -> Lwt.return_ok (Paf.TCP.dst tcp, flow)

--- a/mirage/lE_http_server.mli
+++ b/mirage/lE_http_server.mli
@@ -39,12 +39,17 @@ module Make
     Http_mirage_client.t ->
     (Paf.TLS.flow, Ipaddr.t * int) Alpn.server_handler ->
     (unit, [> `Msg of string ]) result Lwt.t
-  (** [with_lets_encrypt_certificates ?port stackv4v6 ~production cfg http
-      handler] launches 2 servers:
-      1) An HTTP server which handles let's encrypt challenges and redirections
-      2) An ALPN server (HTTP/1.1 and H2) servers to the user's request handler
-
+  (** [with_lets_encrypt_certificates ?port ?alpn_protocols stackv4v6 ~production cfg handler]
+      launches 2 servers:
+      - An HTTP server which handles let's encrypt challenges and redirections
+      - An ALPN server (which handles HTTP/1.1 and H2 by default, otherwise you
+        can specify protocols via the [alpn_protocol] argument) which run the
+        user's request handler
+  
       Every 80 days, the fiber re-askes a new certificate from let's encrypt and
       re-update the ALPN server with this new certificate. The HTTP server does
-      the redirection to the hostname defined into the given [cfg]. *)
+      the redirection to the hostname defined into the given [cfg].
+  
+      {b NOTE}: For the [alpn_protocols] argument, only ["h2"], ["http/1.1"] and
+      ["http/1.0"] are handled. Any others protocols will be {b ignored}! *)
 end

--- a/mirage/lE_http_server.mli
+++ b/mirage/lE_http_server.mli
@@ -4,7 +4,7 @@
     handle [http/1.1] and [h2] requests) through a TLS certificate provided by
     Let's encrypt. The challenge is done {i via} HTTP (unlike the ALPN challenge
     offered by Let's encrypt). The [.well-known/*] path is therefore used and
-    the user should not define such a route. *)
+    the user {b should not} define such a route. *)
 
 module Make
     (Time : Mirage_time.S)
@@ -18,38 +18,49 @@ module Make
     LE.configuration ->
     Http_mirage_client.t ->
     (Tls.Config.own_cert, [> `Msg of string ]) result Lwt.t
-  (** [get_certificates ~yes_my_port_80_is_reachable_and_unused ~production cfg
-      http] tries to resolve the Let's encrypt challenge by initiating an HTTP
-      server on port 80 and handling requests from it with [ocaml-letsencrypt].
+  (** [get_certificates ~yes_my_port_80_is_reachable_and_unused ~production cfg client]
+      tries to resolve the Let's encrypt challenge by initiating an HTTP server
+      on port 80 and handling requests from it with [ocaml-letsencrypt].
 
       This resolution requires that your domain name (requested in the given
       [cfg.hostname]) redirects Let's encrypt to this HTTP server. You probably
       need to check your DNS configuration.
 
-      The [http] value can be made by {!val:Http_mirage_client.Make.connect} to
-      be able to launch HTTP requests to Let's encrypt. *)
+      The [client] value can be made by {!val:Http_mirage_client.Make.connect}
+      to be able to launch HTTP requests to Let's encrypt. *)
 
   module Paf : module type of Paf_mirage.Make (Stack.TCP)
 
   val with_lets_encrypt_certificates :
     ?port:int ->
+    ?alpn_protocols:string list ->
     Stack.t ->
     production:bool ->
     LE.configuration ->
     Http_mirage_client.t ->
     (Paf.TLS.flow, Ipaddr.t * int) Alpn.server_handler ->
     (unit, [> `Msg of string ]) result Lwt.t
-  (** [with_lets_encrypt_certificates ?port ?alpn_protocols stackv4v6 ~production cfg handler]
+  (** [with_lets_encrypt_certificates ?port ?alpn_protocols stackv4v6 ~production cfg client handler]
       launches 2 servers:
-      - An HTTP server which handles let's encrypt challenges and redirections
+      - An HTTP/1.1 server which handles let's encrypt challenges and
+        redirections
       - An ALPN server (which handles HTTP/1.1 and H2 by default, otherwise you
         can specify protocols via the [alpn_protocol] argument) which run the
         user's request handler
+
+      The [client] value can be made by {!val:Http_mirage_client.Make.connect}
+      to be able to launch HTTP requests to Let's encrypt.
   
       Every 80 days, the fiber re-askes a new certificate from let's encrypt and
-      re-update the ALPN server with this new certificate. The HTTP server does
-      the redirection to the hostname defined into the given [cfg].
+      re-update the ALPN server with this new certificate. The HTTP/1.1 server
+      does the redirection to the hostname defined into the given [cfg].
   
       {b NOTE}: For the [alpn_protocols] argument, only ["h2"], ["http/1.1"] and
-      ["http/1.0"] are handled. Any others protocols will be {b ignored}! *)
+      ["http/1.0"] are handled. Any others protocols will be {b ignored}! The
+      order of protocols matters. If ["h2"] is the first one and the client
+      handles the ["h2"] protocol, server and client agree to use this protocol
+      (even if both handle ["http/1.1"]).
+
+      The default value of [alpn_protocols] prioritises ["http/1.1"] as the
+      protocol which should be picked by the client. *)
 end


### PR DESCRIPTION
Requested by @kit-ty-kate to be able to specify `http/1.1` (x)or `h2`: it seems that the `h2` server has some bugs.